### PR TITLE
remove payroll wages option

### DIFF
--- a/R/dash_ui.R
+++ b/R/dash_ui.R
@@ -237,14 +237,6 @@ tab_payrolls <- function(...) {
           ),
           inline = TRUE
         )
-      },
-      input_fn2 = function(id) {
-        selectInput(NS(id, "arg2"),
-          label = "Show total jobs or total wages",
-          choices = c("jobs", "wages"),
-          selected = "jobs",
-          multiple = FALSE
-        )
       }
     ),
     graph_ui("payrolls_byind_bystate",

--- a/R/viz_payrolls_bystate.R
+++ b/R/viz_payrolls_bystate.R
@@ -10,9 +10,9 @@ viz_payrolls_bystate <- function(data = load_data(),
                                    "VIC",
                                    "WA"
                                  ),
-                                 arg2 = "jobs") {
+                                 arg2 = NULL) {
   states <- arg1
-  series <- arg2
+  series <- "jobs"
 
   if (series == "jobs") {
     df <- data$payrolls_industry_jobs


### PR DESCRIPTION
This PR removes the option to display total wages in the payroll jobs + wages by state chart. The underlying data has been removed by the ABS. See also: https://github.com/grattan/macro_dashboard_data/pull/6